### PR TITLE
[WIP] Include New "Stale" Workflow for Support Issues

### DIFF
--- a/.github/global.yml
+++ b/.github/global.yml
@@ -16,11 +16,11 @@
 - name: off-topic
   description: not related to project, discussion is spam, or is otherwise nonsensical
   color: "ff8c00"
-  aliases: [reso-invalid, invalid]
+  aliases: [reso-invalid, invalid, "reso:invalid"]
 - name: works-as-intended
   description: not a bug or feature is undesired; the project functions as intended
   color: "ff8c00"
-  aliases: [reso-wontfix, wontfix]
+  aliases: [reso-wontfix, wontfix, "reso:wontfix"]
 
 # Bots
 - name: cla-signed
@@ -48,7 +48,7 @@
 - name: duplicate
   description: this is a duplicate of another issue
   color: "0c2132"
-  aliases: [reso-duplicate]
+  aliases: [reso-duplicate, "reso:duplicate"]
 - name: duplicate::primary
   description: if an issue has duplicates, this is the consolidated, primary issue
   color: "0c2132"
@@ -58,11 +58,11 @@
 - name: pending::feedback
   description: indicates we are waiting on feedback from the user
   color: "d4c5f9"
-  aliases: [waiting-on-response]
+  aliases: [waiting-on-response, info-needed]
 - name: pending::discussion
   description: contains some ongoing discussion that needs to be resolved prior to proceeding
   color: "d4c5f9"
-  aliases: [type-discussion, 2_Needs_Decision]
+  aliases: [type-discussion, 2_Needs_Decision, "type:discussion"]
 - name: pending::release
   description: the resolution is pending a new release
   color: "d4c5f9"
@@ -91,11 +91,11 @@
 - name: type::bug
   description: describes erroneous operation, use severity::* to classify the type
   color: "b60205"
-  aliases: [bug]
+  aliases: [bug, type-bug, "Type: Bug", "type:bug"]
 - name: type::feature
   description: request for a new feature or capability
   color: "fff2cc"
-  aliases: [tag-features, type-enhancement, enhancement, tag-new_package_type]
+  aliases: [tag-features, type-enhancement, enhancement, tag-new_package_type, type-feature, "Type: Feature", "type:enhancement"]
 - name: type::documentation
   description: request for improved documentation
   color: "fff2cc"
@@ -103,7 +103,7 @@
 - name: type::support
   description: neither a bug nor feature, is really just a user having questions or difficulty somewhere
   color: "fff2cc"
-  aliases: [type-question, question]
+  aliases: [type-question, question, "Type: Question", "type:question"]
 - name: type::tech-debt
   description: identified, requests removal, or resolve some technical debt
   color: "fff2cc"
@@ -113,7 +113,7 @@
 - name: type::task
   description: indicates a change that doesn't pertain to the code itself, e.g. updating CI/CQ, rebuilding package
   color: "fff2cc"
-  aliases: [type-new_test]
+  aliases: [type-new_test, "Type: Maintenance", "type:task"]
 
 # Severity
 - name: severity::1
@@ -147,33 +147,36 @@
 - name: source::qa
   description: created by or for the QA team
   color: "c2e0c6"
+  aliases: ["source:qa"]
 - name: source::enterprise
   description: created by or for an enterprise customer
   color: "c2e0c6"
-  aliases: [source-ent, ent]
+  aliases: [source-ent, ent, "source:enterprise"]
 - name: source::partner
   description: created by or for an Anaconda, Inc. partner company
   color: "c2e0c8"
 - name: source::anaconda
   description: created by members of Anaconda, Inc.
   color: "c2e0c6"
-  aliases: [source-cio, cio]
+  aliases: [source-cio, cio, "source:internal"]
 - name: source::community
   description: catch-all for issues filed by community members
   color: "c2e0c6"
+  aliases: [source-community, "source:public"]
 
 # OS
 - name: os::linux
   description: relevant to Linux
   color: "d0e0e3"
+  aliases: ["os:linux"]
 - name: os::macos
   description: relevant to macOS
   color: "d0e0e3"
-  aliases: [tag-macos, osx, os-mac]
+  aliases: [tag-macos, osx, os-mac, macos, "os:osx"]
 - name: os::windows
   description: relevant to Windows
   color: "d0e0e3"
-  aliases: [tag-windows, windows, os-win]
+  aliases: [tag-windows, windows, os-win, "os:windows"]
 - name: os::wsl
   description: relevant to Windows Subsystem for Linux
   color: "d0e0e3"

--- a/.github/global.yml
+++ b/.github/global.yml
@@ -5,9 +5,11 @@
 - name: good-first-issue
   description: great for new contributors, code change is envisioned to be trivial/relatively straight-forward
   color: "43b049"
+  aliases: ["good first issue"]
 - name: help-wanted
   description: we don't know the solution or we especially want a community member to contribute the code change
   color: "43b049"
+  aliases: ["help wanted"]
 - name: unreproducible
   description: we are unable to replicate the issue
   color: "ff8c00"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,9 +28,9 @@ jobs:
         id: stale
         with:
           # Idle number of days before marking issues stale (default: 60)
-          days-before-issue-stale: 365
+          days-before-issue-stale: ${{ (github.event.label.name == 'type::support') && 21 || 365 }}
           # Idle number of days before closing stale issues/PRs (default: 7)
-          days-before-issue-close: 90
+          days-before-issue-close: ${{ (github.event.label.name == 'type::support') && 7 || 90 }}
           # Idle number of days before marking PRs stale (default: 60)
           days-before-pr-stale: 365
           # Idle number of days before closing stale PRs (default: 7)

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -21,3 +21,6 @@ jobs:
           PR_LABELS: false
           COMMIT_BODY: Sync from infra
           CONFIG_PATH: .github/sync.yml
+          COMMIT_EACH_FILE: false
+          GIT_USERNAME: Conda Bot
+          GIT_EMAIL: conda-bot@users.noreply.github.com

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - .github/sync.yml  # trigger sync if sync config is modified
+      - .github/workflows/sync.yml  # trigger sync if sync workflow is modified
       - .github/workflows/boards.yml
       - .github/workflows/issues.yml
       - .github/workflows/labels.yml

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           GH_PAT: ${{ secrets.SYNC_TOKEN }}
           PR_LABELS: false
-          COMMIT_BODY: Sync from infra
           CONFIG_PATH: .github/sync.yml
           COMMIT_EACH_FILE: false
           GIT_USERNAME: Conda Bot


### PR DESCRIPTION
Depends-on https://github.com/conda/infra/pull/508

We need a new GitHub Actions workflow for closing out stale issues which have the `type::support` label on them.